### PR TITLE
Note undo/redo and canvas improvements

### DIFF
--- a/e2e/helpers/convex-helpers.ts
+++ b/e2e/helpers/convex-helpers.ts
@@ -1,0 +1,64 @@
+import { readFile } from 'node:fs/promises'
+import { ConvexHttpClient } from 'convex/browser'
+import { api } from 'convex/_generated/api'
+import { AUTH_STORAGE_PATH } from './constants'
+import type { Id } from 'convex/_generated/dataModel'
+
+const CONVEX_AUTH_COOKIE = '__Secure-better-auth.convex_jwt'
+
+interface StorageState {
+  cookies: Array<{
+    name: string
+    value: string
+  }>
+}
+
+export async function getCampaignIdFromRoute({
+  dmUsername,
+  slug,
+}: {
+  dmUsername: string
+  slug: string
+}): Promise<Id<'campaigns'>> {
+  const client = await createE2EConvexClient()
+  const campaign = await client.query(api.campaigns.queries.getCampaignBySlug, {
+    dmUsername,
+    slug,
+  })
+  return campaign._id
+}
+
+export async function getSidebarItemIdBySlug({
+  campaignId,
+  slug,
+}: {
+  campaignId: Id<'campaigns'>
+  slug: string
+}): Promise<Id<'sidebarItems'>> {
+  const client = await createE2EConvexClient()
+  const item = await client.query(api.sidebarItems.queries.getSidebarItemBySlug, {
+    campaignId,
+    slug,
+  })
+  if (!item) {
+    throw new Error(`Unable to find sidebar item with slug "${slug}"`)
+  }
+  return item._id
+}
+
+async function createE2EConvexClient() {
+  const convexUrl = process.env.VITE_CONVEX_URL
+  if (!convexUrl) {
+    throw new Error('VITE_CONVEX_URL is required for E2E Convex helpers')
+  }
+
+  const storage = JSON.parse(await readFile(AUTH_STORAGE_PATH, 'utf8')) as StorageState
+  const jwt = storage.cookies.find((cookie) => cookie.name === CONVEX_AUTH_COOKIE)?.value
+  if (!jwt) {
+    throw new Error(`Missing ${CONVEX_AUTH_COOKIE} in ${AUTH_STORAGE_PATH}`)
+  }
+
+  const client = new ConvexHttpClient(convexUrl)
+  client.setAuth(jwt)
+  return client
+}

--- a/e2e/helpers/convex-helpers.ts
+++ b/e2e/helpers/convex-helpers.ts
@@ -25,6 +25,9 @@ export async function getCampaignIdFromRoute({
     dmUsername,
     slug,
   })
+  if (!campaign) {
+    throw new Error(`Campaign not found for dmUsername=${dmUsername}, slug=${slug}`)
+  }
   return campaign._id
 }
 
@@ -52,7 +55,22 @@ async function createE2EConvexClient() {
     throw new Error('VITE_CONVEX_URL is required for E2E Convex helpers')
   }
 
-  const storage = JSON.parse(await readFile(AUTH_STORAGE_PATH, 'utf8')) as StorageState
+  let authStorage: string
+  try {
+    authStorage = await readFile(AUTH_STORAGE_PATH, 'utf8')
+  } catch (error) {
+    throw new Error(`Error reading auth storage at ${AUTH_STORAGE_PATH}: ${getErrorMessage(error)}`)
+  }
+
+  let storage: StorageState
+  try {
+    storage = JSON.parse(authStorage) as StorageState
+  } catch (error) {
+    throw new Error(
+      `Error parsing auth storage JSON at ${AUTH_STORAGE_PATH}: ${getErrorMessage(error)}`,
+    )
+  }
+
   const jwt = storage.cookies.find((cookie) => cookie.name === CONVEX_AUTH_COOKIE)?.value
   if (!jwt) {
     throw new Error(`Missing ${CONVEX_AUTH_COOKIE} in ${AUTH_STORAGE_PATH}`)
@@ -61,4 +79,8 @@ async function createE2EConvexClient() {
   const client = new ConvexHttpClient(convexUrl)
   client.setAuth(jwt)
   return client
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
 }

--- a/e2e/undo-redo-hotkeys.spec.ts
+++ b/e2e/undo-redo-hotkeys.spec.ts
@@ -1,0 +1,429 @@
+import { expect, test } from '@playwright/test'
+import { createCampaign, deleteCampaign, navigateToCampaign } from './helpers/campaign-helpers'
+import {
+  clickCanvasAt,
+  clearCanvasViaRuntime,
+  createFreshCanvasForTest,
+  enableCanvasRuntime,
+  getCanvasNodeById,
+  getCanvasNodes,
+  seedCanvasEmbedNodeViaRuntime,
+  selectCanvasTool,
+} from './helpers/canvas-helpers'
+import { AUTH_STORAGE_PATH, testName } from './helpers/constants'
+import { getEditor } from './helpers/editor-helpers'
+import { getCampaignIdFromRoute, getSidebarItemIdBySlug } from './helpers/convex-helpers'
+import { getBrowserPrimaryModifier, pressRedo, pressUndo } from './helpers/keyboard-helpers'
+import { createNote, openItem } from './helpers/sidebar-helpers'
+import type { Page } from '@playwright/test'
+import type { Id } from 'convex/_generated/dataModel'
+
+const campaignName = testName('URHotkeys')
+
+test.describe.serial('undo and redo hotkeys in editor surfaces', () => {
+  test.setTimeout(90_000)
+
+  test.beforeAll(async ({ browser }) => {
+    const context = await browser.newContext({ storageState: AUTH_STORAGE_PATH })
+    const page = await context.newPage()
+    await page.goto('/campaigns')
+    await createCampaign(page, campaignName)
+    await page.close()
+    await context.close()
+  })
+
+  test('routes undo and redo to the active note editor', async ({ page }) => {
+    await page.goto('/campaigns')
+    await navigateToCampaign(page, campaignName)
+
+    const noteName = `Undo Note ${Date.now()}`
+    await createNote(page, noteName)
+    await openItem(page, noteName)
+
+    const editor = await getEditor(page)
+    await editor.click()
+
+    const baseText = 'Base'
+    const text = 'N'
+    await page.keyboard.type(baseText)
+    await expect(editor).toContainText(baseText)
+    await waitForEditorToSettle(page)
+    await page.keyboard.type(text)
+    await expect(editor).toContainText(`${baseText}${text}`)
+
+    await pressUndo(page)
+    await expect(editor).not.toContainText(text, { timeout: 5000 })
+    await expect(editor).toContainText(baseText)
+
+    await pressNoteRedo(page)
+    await expect(editor).toContainText(`${baseText}${text}`, { timeout: 5000 })
+  })
+
+  test('keeps the note cursor in the edited paragraph after undo and redo', async ({ page }) => {
+    await page.goto('/campaigns')
+    await navigateToCampaign(page, campaignName)
+
+    const noteName = `Undo Cursor Note ${Date.now()}`
+    await createNote(page, noteName)
+    await openItem(page, noteName)
+
+    const editor = await getEditor(page)
+    await editor.click()
+    await page.keyboard.type('Top')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('Middle')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('Bottom')
+    await expect(editor).toContainText('Top')
+    await expect(editor).toContainText('Middle')
+    await expect(editor).toContainText('Bottom')
+    await waitForEditorToSettle(page)
+
+    await placeCaretAfterText(editor, 'Middle')
+    await page.keyboard.type('X')
+    await expect(editor).toContainText('MiddleX')
+    await expect.poll(() => getSelectionTextBlock(page, editor)).toContain('MiddleX')
+
+    await pressUndo(page)
+    await expect(editor).toContainText('Middle')
+    await expect(editor).not.toContainText('MiddleX')
+    await expect.poll(() => getSelectionTextBlock(page, editor)).toContain('Middle')
+
+    await pressNoteRedo(page)
+    await expect(editor).toContainText('MiddleX')
+    await expect.poll(() => getSelectionTextBlock(page, editor)).toContain('MiddleX')
+  })
+
+  test('restores note selection after repeated undo and redo', async ({ page }) => {
+    await page.goto('/campaigns')
+    await navigateToCampaign(page, campaignName)
+
+    const noteName = `Undo Selection Roundtrip Note ${Date.now()}`
+    await createNote(page, noteName)
+    await openItem(page, noteName)
+
+    const editor = await getEditor(page)
+    await editor.click()
+    await page.keyboard.type('Top')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('Middle')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('Bottom')
+    await waitForEditorToSettle(page)
+
+    await placeCaretAfterText(editor, 'Top')
+    await page.keyboard.type('A')
+    await expect(editor).toContainText('TopA')
+    await waitForEditorToSettle(page)
+
+    await placeCaretAfterText(editor, 'Middle')
+    await page.keyboard.type('Z')
+    await expect(editor).toContainText('MiddleZ')
+    await waitForEditorToSettle(page)
+
+    await selectText(editor, 'Bottom')
+    await expect.poll(() => getSelectedText(page)).toBe('Bottom')
+
+    await pressUndo(page)
+    await expect.poll(() => getEditorText(editor)).not.toContain('MiddleZ')
+    await pressUndo(page)
+    await expect.poll(() => getEditorText(editor)).not.toContain('TopA')
+    await pressNoteRedo(page)
+    await expect.poll(() => getEditorText(editor)).toContain('TopA')
+    await pressNoteRedo(page)
+    await expect.poll(() => getEditorText(editor)).toContain('MiddleZ')
+
+    await expect.poll(() => getSelectedText(page)).toBe('Bottom')
+  })
+
+  test('restores the exact note text and multi-line selection after repeated undo and redo pairs', async ({
+    page,
+  }) => {
+    await page.goto('/campaigns')
+    await navigateToCampaign(page, campaignName)
+
+    const noteName = `Undo Exact Selection Note ${Date.now()}`
+    await createNote(page, noteName)
+    await openItem(page, noteName)
+
+    const editor = await getEditor(page)
+    await editor.click()
+    await page.keyboard.type('Alpha')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('Beta')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('Gamma')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('Delta')
+    await waitForEditorToSettle(page)
+
+    await placeCaretAfterText(editor, 'Alpha')
+    await page.keyboard.type('X')
+    await expect(editor).toContainText('AlphaX')
+    await waitForEditorToSettle(page)
+
+    await placeCaretAfterText(editor, 'Delta')
+    await page.keyboard.type('Y')
+    await expect(editor).toContainText('DeltaY')
+    await waitForEditorToSettle(page)
+
+    await selectTextRange(editor, 'Beta', 'Gamma')
+    const expected = await getEditorSelectionSnapshot(editor)
+
+    await pressUndo(page)
+    await expect.poll(() => getEditorText(editor)).not.toContain('DeltaY')
+    await pressNoteRedo(page)
+    await expect.poll(() => getEditorSelectionSnapshot(editor)).toEqual(expected)
+
+    await pressUndo(page)
+    await expect.poll(() => getEditorText(editor)).not.toContain('DeltaY')
+    await pressNoteRedo(page)
+    await expect.poll(() => getEditorSelectionSnapshot(editor)).toEqual(expected)
+  })
+
+  test.afterAll(async ({ browser }) => {
+    const context = await browser.newContext({ storageState: AUTH_STORAGE_PATH })
+    const page = await context.newPage()
+    await page.goto('/campaigns')
+    try {
+      await deleteCampaign(page, campaignName)
+    } finally {
+      await page.close()
+      await context.close()
+    }
+  })
+
+  test('routes undo and redo to the active canvas text node editor', async ({ page }) => {
+    await openFreshRuntimeCanvas(page, `Undo Text Canvas ${Date.now()}`)
+    await selectCanvasTool(page, 'Text')
+    await clickCanvasAt(page, { x: 360, y: 260 })
+
+    const editor = page.locator('[aria-label="Text node content"][contenteditable="true"]')
+    await expect(editor).toHaveCount(1)
+    await expect(editor).toBeVisible()
+
+    const text = 'T'
+    await page.keyboard.type(text)
+    await expect(editor).toContainText(text)
+
+    await pressUndo(page)
+    await expect(editor).not.toContainText(text, { timeout: 5000 })
+    await expect.poll(() => getCanvasNodes(page).count()).toBe(1)
+
+    await pressRedo(page)
+    await expect(editor).toContainText(text, { timeout: 5000 })
+    await expect.poll(() => getCanvasNodes(page).count()).toBe(1)
+  })
+
+  test('routes undo and redo to the active embedded note editor', async ({ page }) => {
+    await page.goto('/campaigns')
+    await navigateToCampaign(page, campaignName)
+    const noteName = `Undo Embed Note ${Date.now()}`
+    await createNote(page, noteName)
+    const noteId = await getCurrentNoteId(page)
+
+    await openFreshRuntimeCanvas(page, `Undo Embed Canvas ${Date.now()}`)
+    await seedCanvasEmbedNodeViaRuntime(page, {
+      id: 'embedded-note-undo',
+      sidebarItemId: noteId,
+      position: { x: 220, y: 180 },
+      width: 420,
+      height: 280,
+    })
+
+    await getCanvasNodeById(page, 'embedded-note-undo').dblclick()
+    await expect(page.getByTestId('embed-note-content-wrapper')).toBeVisible({ timeout: 15_000 })
+
+    const embeddedEditor = page
+      .getByTestId('embed-note-content-wrapper')
+      .locator('[contenteditable="true"]')
+      .first()
+    await expect(embeddedEditor).toBeVisible({ timeout: 15_000 })
+    await waitForEditorToSettle(page)
+
+    const baseText = 'Base'
+    const text = 'E'
+    await embeddedEditor.click()
+    await page.keyboard.type(baseText)
+    await expect(embeddedEditor).toContainText(baseText)
+    await waitForEditorToSettle(page)
+    await page.keyboard.type(text)
+    await expect(embeddedEditor).toContainText(`${baseText}${text}`)
+
+    await pressUndo(page)
+    await expect(embeddedEditor).not.toContainText(text, { timeout: 5000 })
+    await expect(embeddedEditor).toContainText(baseText)
+    await expect.poll(() => getCanvasNodes(page).count()).toBe(1)
+
+    await pressNoteRedo(page)
+    await expect(embeddedEditor).toContainText(`${baseText}${text}`, { timeout: 5000 })
+    await expect.poll(() => getCanvasNodes(page).count()).toBe(1)
+  })
+})
+
+async function openFreshRuntimeCanvas(page: Page, canvasName: string) {
+  await enableCanvasRuntime(page)
+  await createFreshCanvasForTest(page, campaignName, canvasName)
+  await clearCanvasViaRuntime(page)
+  await selectCanvasTool(page, 'Pointer')
+}
+
+async function getCurrentNoteId(page: Page): Promise<Id<'sidebarItems'>> {
+  const noteSlug = getCurrentItemSlug(page)
+  const { dmUsername, campaignSlug } = getCurrentCampaignRoute(page)
+  const campaignId = await getCampaignIdFromRoute({ dmUsername, slug: campaignSlug })
+  return await getSidebarItemIdBySlug({ campaignId, slug: noteSlug })
+}
+
+function getCurrentCampaignRoute(page: Page) {
+  const url = new URL(page.url())
+  const [, campaignsSegment, dmUsername, campaignSlug] = url.pathname.split('/')
+  if (campaignsSegment !== 'campaigns' || !dmUsername || !campaignSlug) {
+    throw new Error(`Expected a campaign route, received ${url.pathname}`)
+  }
+  return { dmUsername, campaignSlug }
+}
+
+function getCurrentItemSlug(page: Page) {
+  const itemSlug = new URL(page.url()).searchParams.get('item')
+  if (!itemSlug) {
+    throw new Error(`Expected an item slug in ${page.url()}`)
+  }
+  return itemSlug
+}
+
+async function waitForEditorToSettle(page: Page) {
+  await page.waitForTimeout(1000)
+}
+
+async function pressNoteRedo(page: Page) {
+  const modifier = await getBrowserPrimaryModifier(page)
+  if (modifier === 'Meta') {
+    await page.keyboard.press('Meta+Shift+Z')
+    return
+  }
+
+  await page.keyboard.press('Control+Y')
+}
+
+async function placeCaretAfterText(editor: Awaited<ReturnType<typeof getEditor>>, text: string) {
+  await editor.evaluate((root, targetText) => {
+    const findTextNode = (nodeRoot: Node, textToFind: string) => {
+      const walker = document.createTreeWalker(nodeRoot, NodeFilter.SHOW_TEXT)
+      let node = walker.nextNode()
+      while (node) {
+        if (node.textContent?.includes(textToFind)) return node
+        node = walker.nextNode()
+      }
+      return null
+    }
+
+    const textNode = findTextNode(root, targetText)
+    if (!textNode) throw new Error(`Could not find text node containing ${targetText}`)
+
+    const offset = textNode.textContent?.indexOf(targetText) ?? -1
+    if (offset === -1) throw new Error(`Could not find text offset for ${targetText}`)
+
+    const range = document.createRange()
+    range.setStart(textNode, offset + targetText.length)
+    range.collapse(true)
+
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    ;(root as HTMLElement).focus()
+    document.dispatchEvent(new Event('selectionchange'))
+  }, text)
+}
+
+async function selectText(editor: Awaited<ReturnType<typeof getEditor>>, text: string) {
+  await selectTextRange(editor, text, text)
+}
+
+async function selectTextRange(
+  editor: Awaited<ReturnType<typeof getEditor>>,
+  startText: string,
+  endText: string,
+) {
+  await editor.evaluate(
+    (root, textRange) => {
+      const findTextNode = (nodeRoot: Node, textToFind: string) => {
+        const walker = document.createTreeWalker(nodeRoot, NodeFilter.SHOW_TEXT)
+        let node = walker.nextNode()
+        while (node) {
+          if (node.textContent?.includes(textToFind)) return node
+          node = walker.nextNode()
+        }
+        return null
+      }
+
+      const startNode = findTextNode(root, textRange.startText)
+      const endNode = findTextNode(root, textRange.endText)
+      if (!startNode) throw new Error(`Could not find text node containing ${textRange.startText}`)
+      if (!endNode) throw new Error(`Could not find text node containing ${textRange.endText}`)
+
+      const startOffset = startNode.textContent?.indexOf(textRange.startText) ?? -1
+      const endOffset = endNode.textContent?.indexOf(textRange.endText) ?? -1
+      if (startOffset === -1) {
+        throw new Error(`Could not find text offset for ${textRange.startText}`)
+      }
+      if (endOffset === -1) throw new Error(`Could not find text offset for ${textRange.endText}`)
+
+      const range = document.createRange()
+      range.setStart(startNode, startOffset)
+      range.setEnd(endNode, endOffset + textRange.endText.length)
+
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      ;(root as HTMLElement).focus()
+      document.dispatchEvent(new Event('selectionchange'))
+    },
+    { startText, endText },
+  )
+}
+
+async function getSelectedText(page: Page) {
+  return await page.evaluate(() => window.getSelection()?.toString() ?? '')
+}
+
+async function getEditorText(editor: Awaited<ReturnType<typeof getEditor>>) {
+  return await editor.evaluate((root) => root.textContent ?? '')
+}
+
+async function getEditorSelectionSnapshot(editor: Awaited<ReturnType<typeof getEditor>>) {
+  return await editor.evaluate((root) => {
+    const selection = window.getSelection()
+    const anchorNode = selection?.anchorNode ?? null
+    const focusNode = selection?.focusNode ?? null
+
+    const getRootTextOffset = (targetNode: Node | null, targetOffset: number) => {
+      if (!targetNode || !root.contains(targetNode)) return null
+
+      const range = document.createRange()
+      range.setStart(root, 0)
+      range.setEnd(targetNode, targetOffset)
+      return range.toString().length
+    }
+
+    return {
+      text: root.textContent ?? '',
+      selectedText: selection?.toString() ?? '',
+      anchorOffset: getRootTextOffset(anchorNode, selection?.anchorOffset ?? 0),
+      focusOffset: getRootTextOffset(focusNode, selection?.focusOffset ?? 0),
+      isCollapsed: selection?.isCollapsed ?? true,
+    }
+  })
+}
+
+async function getSelectionTextBlock(_page: Page, editor: Awaited<ReturnType<typeof getEditor>>) {
+  return await editor.evaluate((root) => {
+    const selection = window.getSelection()
+    const anchorNode = selection?.anchorNode
+    if (!anchorNode || !root.contains(anchorNode)) return null
+
+    const element =
+      anchorNode.nodeType === Node.ELEMENT_NODE ? (anchorNode as Element) : anchorNode.parentElement
+    return element?.closest('[data-content-type]')?.textContent ?? anchorNode.textContent ?? null
+  })
+}

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
+    "y-prosemirror": "1.3.7",
     "y-protocols": "^1.0.6",
     "yjs": "^13.6.29",
     "zod": "^4.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      y-prosemirror:
+        specifier: 1.3.7
+        version: 1.3.7(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)
       y-protocols:
         specifier: ^1.0.6
         version: 1.0.7(yjs@13.6.29)

--- a/src/features/canvas/runtime/interaction/__tests__/canvas-pointer-router.test.ts
+++ b/src/features/canvas/runtime/interaction/__tests__/canvas-pointer-router.test.ts
@@ -258,6 +258,22 @@ describe('createCanvasPointerRouter', () => {
     detach()
   })
 
+  it('returns to the pointer tool when a lasso gesture finishes', () => {
+    const { surface, node } = createCanvasDom()
+    const setActiveTool = vi.fn()
+    const router = createCanvasPointerRouter()
+    router.setOptions(createRouterOptions({ activeTool: 'lasso', setActiveTool }))
+    const detach = router.attach(surface)
+
+    node.dispatchEvent(createPointerEvent('pointerdown', { clientX: 0, clientY: 0 }))
+    window.dispatchEvent(createPointerEvent('pointermove', { clientX: 100, clientY: 0 }))
+    window.dispatchEvent(createPointerEvent('pointerup', { clientX: 100, clientY: 100 }))
+
+    expect(setActiveTool).toHaveBeenCalledExactlyOnceWith('select')
+
+    detach()
+  })
+
   it('routes non-selection tool gestures through fixed handlers for the whole gesture', () => {
     const { surface, viewport } = createCanvasDom()
     const initialHandlers: CanvasToolHandlers = {
@@ -360,6 +376,7 @@ describe('createCanvasPointerRouter', () => {
 function createRouterOptions({
   activeTool,
   activeToolHandlers = {},
+  setActiveTool = vi.fn(),
   nodeDragController = null,
   selection = createSelectionMock(),
   nodes = [],
@@ -368,6 +385,7 @@ function createRouterOptions({
 }: {
   activeTool: CanvasToolId
   activeToolHandlers?: CanvasToolHandlers
+  setActiveTool?: CanvasPointerRouterOptions['setActiveTool']
   nodeDragController?: CanvasPointerRouterOptions['nodeDragController']
   selection?: ReturnType<typeof createSelectionMock>
   nodes?: Array<Node>
@@ -385,6 +403,7 @@ function createRouterOptions({
     getShiftPressed: () => false,
     nodeDragController,
     selection,
+    setActiveTool,
     viewportController: {
       getZoom: () => 1,
       screenToCanvasPosition: ({ x, y }) => ({ x, y }),

--- a/src/features/canvas/runtime/interaction/canvas-keyboard-targets.ts
+++ b/src/features/canvas/runtime/interaction/canvas-keyboard-targets.ts
@@ -33,5 +33,7 @@ export function isCanvasHotkeyTarget(
   }
 
   const activeElement = globalThis.document?.activeElement
+  // Canvas keyboard handling calls focus() on the surface, so keep hotkeys active
+  // when focus is inside the canvas even if the key event target is outside it.
   return activeElement instanceof Element && surfaceElement.contains(activeElement)
 }

--- a/src/features/canvas/runtime/interaction/canvas-pointer-router.ts
+++ b/src/features/canvas/runtime/interaction/canvas-pointer-router.ts
@@ -30,6 +30,7 @@ type ActivePointerGesture =
   | {
       kind: 'selection'
       pointerId: number
+      activeTool: CanvasToolId
       startTargetKind: CanvasPointerTarget['kind']
       controller: ReturnType<typeof createCanvasSelectionGestureController>
       startPoint: { x: number; y: number }
@@ -64,6 +65,7 @@ export interface CanvasPointerRouterOptions {
     | 'setGesturePreview'
   >
   getShiftPressed: () => boolean
+  setActiveTool: (tool: CanvasToolId) => void
 }
 
 export interface CanvasPointerRouter {
@@ -174,6 +176,7 @@ export function createCanvasPointerRouter(): CanvasPointerRouter {
       beginSelectionGesture(
         event,
         target,
+        currentOptions.activeTool,
         createRectangleSelectionGesture(currentOptions, interaction),
       )
       return
@@ -181,7 +184,12 @@ export function createCanvasPointerRouter(): CanvasPointerRouter {
 
     if (currentOptions.activeTool === 'lasso' && target.kind !== 'blocked-interactive-child') {
       claimCanvasPointerEvent(event)
-      beginSelectionGesture(event, target, createLassoSelectionGesture(currentOptions, interaction))
+      beginSelectionGesture(
+        event,
+        target,
+        currentOptions.activeTool,
+        createLassoSelectionGesture(currentOptions, interaction),
+      )
       return
     }
 
@@ -205,6 +213,7 @@ export function createCanvasPointerRouter(): CanvasPointerRouter {
   const beginSelectionGesture = (
     event: PointerEvent,
     target: CanvasPointerTarget,
+    activeTool: CanvasToolId,
     controller: ReturnType<typeof createCanvasSelectionGestureController>,
   ) => {
     const input = getPointerInput(event)
@@ -213,6 +222,7 @@ export function createCanvasPointerRouter(): CanvasPointerRouter {
     activeGesture = {
       kind: 'selection',
       pointerId: event.pointerId,
+      activeTool,
       startTargetKind: target.kind,
       controller,
       startPoint: input.clientPoint,
@@ -252,6 +262,9 @@ export function createCanvasPointerRouter(): CanvasPointerRouter {
       const committed = activeGesture.controller.commit(getPointerInput(event))
       if (!committed) {
         maybeClearSelectionFromPointGesture(event, activeGesture)
+      }
+      if (activeGesture.activeTool === 'lasso') {
+        requireOptions(options).setActiveTool('select')
       }
       endActiveGesture()
       return

--- a/src/features/canvas/runtime/use-canvas-interaction-runtime.ts
+++ b/src/features/canvas/runtime/use-canvas-interaction-runtime.ts
@@ -145,6 +145,7 @@ export function useCanvasInteractionRuntime({
       getShiftPressed: () => modifiers.shiftPressed,
       nodeDragController: dragHandlers,
       selection,
+      setActiveTool: (tool) => useCanvasToolStore.getState().setActiveTool(tool),
       viewportController,
     },
   })

--- a/src/features/editor/components/__tests__/note-content.test.tsx
+++ b/src/features/editor/components/__tests__/note-content.test.tsx
@@ -74,11 +74,6 @@ vi.mock('~/features/editor/utils/destroy-blocknote-editor', () => ({
   destroyBlockNoteEditor: vi.fn(),
 }))
 
-vi.mock('~/features/editor/utils/patch-yundo-destroy', () => ({
-  patchYSyncAfterTypeChanged: vi.fn(),
-  patchYUndoPluginDestroy: vi.fn(),
-}))
-
 vi.mock('~/features/campaigns/hooks/useCampaign', () => ({
   useCampaign: () => campaignState,
 }))

--- a/src/features/editor/components/__tests__/note-view.test.tsx
+++ b/src/features/editor/components/__tests__/note-view.test.tsx
@@ -1,0 +1,125 @@
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NoteView } from '../note-view'
+import type { CustomBlockNoteEditor } from 'convex/notes/editorSpecs'
+import type { LinkResolver } from '~/features/editor/hooks/useLinkResolver'
+
+const mockPatchYSyncAfterTypeChanged = vi.hoisted(() => vi.fn())
+const mockPatchYUndoPluginDestroy = vi.hoisted(() => vi.fn())
+
+vi.mock('@blocknote/shadcn', () => ({
+  BlockNoteView: ({
+    children,
+    editor,
+    className,
+    style,
+  }: React.HTMLAttributes<HTMLDivElement> & {
+    children?: React.ReactNode
+    editor: CustomBlockNoteEditor
+  }) => (
+    <div className={className} data-testid="block-note-view" style={style}>
+      <div
+        data-testid="block-note-editable"
+        ref={(node) => {
+          const dom = editor._tiptapEditor.view.dom
+          if (node && !node.contains(dom)) node.append(dom)
+        }}
+      />
+      {children}
+    </div>
+  ),
+}))
+
+vi.mock('@blocknote/react', () => ({
+  SideMenuController: () => null,
+}))
+
+vi.mock('../extensions/prevent-external-drop/prevent-external-drop', () => ({
+  PreventExternalDrop: () => null,
+}))
+
+vi.mock('../extensions/side-menu/side-menu', () => ({
+  SideMenuRenderer: () => null,
+}))
+
+vi.mock('../extensions/slash-menu/slash-menu', () => ({
+  SlashMenu: () => null,
+}))
+
+vi.mock('~/features/editor/hooks/useWikiLinkExtension', () => ({
+  useWikiLinkExtension: vi.fn(),
+}))
+
+vi.mock('~/features/editor/hooks/useMdLinkExtension', () => ({
+  useMdLinkExtension: vi.fn(),
+}))
+
+vi.mock('~/features/editor/hooks/useDisableAutolink', () => ({
+  useDisableAutolink: vi.fn(),
+}))
+
+vi.mock('~/features/settings/hooks/useTheme', () => ({
+  useResolvedTheme: () => 'light',
+}))
+
+vi.mock('~/features/editor/utils/patch-yundo-destroy', () => ({
+  patchYSyncAfterTypeChanged: mockPatchYSyncAfterTypeChanged,
+  patchYUndoPluginDestroy: mockPatchYUndoPluginDestroy,
+}))
+
+describe('NoteView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('patches collaborative Yjs undo on the mounted editor view', () => {
+    const { editor, view } = createEditor()
+
+    render(<NoteView editor={editor} editable linkResolver={createLinkResolver()} />)
+
+    expect(mockPatchYUndoPluginDestroy).toHaveBeenCalledWith(view)
+    expect(mockPatchYSyncAfterTypeChanged).toHaveBeenCalledWith(view)
+  })
+})
+
+function createEditor() {
+  const dom = document.createElement('div')
+  const view = {
+    dom,
+    hasFocus: vi.fn(() => false),
+  }
+  const editor = {
+    document: [createBlock('current')],
+    replaceBlocks: vi.fn(),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    _tiptapEditor: {
+      view,
+    },
+  } as unknown as CustomBlockNoteEditor
+
+  return {
+    editor,
+    dom,
+    view,
+  }
+}
+
+function createBlock(id: string) {
+  return {
+    id,
+    type: 'paragraph',
+    props: {},
+    content: [],
+    children: [],
+  } as unknown as CustomBlockNoteEditor['document'][number]
+}
+
+function createLinkResolver(): LinkResolver {
+  return {
+    isViewerMode: false,
+    resolveLink: vi.fn(),
+    allItems: [],
+    itemsMap: new Map(),
+  }
+}

--- a/src/features/editor/components/note-content.tsx
+++ b/src/features/editor/components/note-content.tsx
@@ -19,10 +19,6 @@ import { useOwnedBlockNoteEditor } from '~/features/editor/hooks/useOwnedBlockNo
 import { useAuthQuery } from '~/shared/hooks/useAuthQuery'
 import { getCursorColor } from '~/features/editor/utils/cursor-colors'
 import { destroyBlockNoteEditor } from '~/features/editor/utils/destroy-blocknote-editor'
-import {
-  patchYSyncAfterTypeChanged,
-  patchYUndoPluginDestroy,
-} from '~/features/editor/utils/patch-yundo-destroy'
 import { effectiveHasAtLeastPermission } from '~/features/sharing/utils/permission-utils'
 import { useActiveSidebarItems } from '~/features/sidebar/hooks/useSidebarItems'
 import { useCampaign } from '~/features/campaigns/hooks/useCampaign'
@@ -397,15 +393,6 @@ function CollaborativeEditorInner({
       if (!isCustomBlockNoteEditor(createdEditor)) {
         throw new Error('Created editor does not match CustomBlockNoteEditor')
       }
-
-      try {
-        patchYUndoPluginDestroy(createdEditor._tiptapEditor.view)
-        patchYSyncAfterTypeChanged(createdEditor._tiptapEditor.view)
-      } catch (error) {
-        destroyNoteEditor(createdEditor, noteId, 'collaborative')
-        throw error
-      }
-
       return createdEditor
     } catch (error) {
       console.error('Error creating BlockNoteEditor for collaborative note content', {

--- a/src/features/editor/components/note-view.tsx
+++ b/src/features/editor/components/note-view.tsx
@@ -1,5 +1,6 @@
 import { BlockNoteView } from '@blocknote/shadcn'
 import { SideMenuController } from '@blocknote/react'
+import { useEffect, useRef } from 'react'
 import { PreventExternalDrop } from './extensions/prevent-external-drop/prevent-external-drop'
 import { SideMenuRenderer } from './extensions/side-menu/side-menu'
 import { SlashMenu } from './extensions/slash-menu/slash-menu'
@@ -12,6 +13,11 @@ import { useWikiLinkExtension } from '~/features/editor/hooks/useWikiLinkExtensi
 import { useMdLinkExtension } from '~/features/editor/hooks/useMdLinkExtension'
 import { useDisableAutolink } from '~/features/editor/hooks/useDisableAutolink'
 import { useResolvedTheme } from '~/features/settings/hooks/useTheme'
+import {
+  patchYSyncAfterTypeChanged,
+  patchYUndoPluginDestroy,
+  runYjsHistoryCommand,
+} from '~/features/editor/utils/patch-yundo-destroy'
 import type { LinkResolver } from '~/features/editor/hooks/useLinkResolver'
 
 interface NoteViewProps {
@@ -38,29 +44,104 @@ export function NoteView({
   useWikiLinkExtension(editor, linkResolver, isViewerMode)
   useMdLinkExtension(editor, linkResolver, isViewerMode)
   useDisableAutolink(editor)
+  useYjsUndoPatches(editor)
+  const noteSurfaceRef = useNoteYjsUndoShortcutPatch(editor, !isViewerMode)
 
   return (
-    <BlockNoteView
-      className={className}
-      editor={editor}
-      style={style}
-      theme={resolvedTheme}
-      editable={editable}
-      sideMenu={false}
-      formattingToolbar={false}
-      slashMenu={false}
-      linkToolbar={false}
-    >
-      {editable && (
-        <>
-          <PreventExternalDrop />
-          {note && (
-            <SideMenuController sideMenu={(props) => <SideMenuRenderer {...props} note={note} />} />
-          )}
-          <SlashMenu editor={editor} />
-        </>
-      )}
-      {children}
-    </BlockNoteView>
+    <div ref={noteSurfaceRef} className="contents">
+      <BlockNoteView
+        className={className}
+        editor={editor}
+        style={style}
+        theme={resolvedTheme}
+        editable={editable}
+        sideMenu={false}
+        formattingToolbar={false}
+        slashMenu={false}
+        linkToolbar={false}
+      >
+        {editable && (
+          <>
+            <PreventExternalDrop />
+            {note && (
+              <SideMenuController
+                sideMenu={(props) => <SideMenuRenderer {...props} note={note} />}
+              />
+            )}
+            <SlashMenu editor={editor} />
+          </>
+        )}
+        {children}
+      </BlockNoteView>
+    </div>
   )
+}
+
+function useYjsUndoPatches(editor: CustomBlockNoteEditor) {
+  useEffect(() => {
+    patchEditorYjsUndo(editor)
+  }, [editor])
+}
+
+function useNoteYjsUndoShortcutPatch(editor: CustomBlockNoteEditor, editable: boolean) {
+  const noteSurfaceRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const surface = noteSurfaceRef.current
+    if (!editable || !surface) return
+
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (!isHistoryShortcut(event) || !isEventInsideNoteSurface(event, editor, surface)) return
+      patchEditorYjsUndo(editor)
+      event.preventDefault()
+      event.stopPropagation()
+      runYjsHistoryCommand(editor._tiptapEditor.view, getHistoryDirection(event))
+    }
+
+    window.addEventListener('keydown', handleKeyDown, { capture: true })
+    return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
+  }, [editable, editor])
+
+  return noteSurfaceRef
+}
+
+function isHistoryShortcut(event: globalThis.KeyboardEvent) {
+  if (event.altKey || (!event.ctrlKey && !event.metaKey)) return false
+
+  const key = event.key.toLowerCase()
+  return key === 'z' || (event.ctrlKey && !event.metaKey && key === 'y')
+}
+
+function getHistoryDirection(event: globalThis.KeyboardEvent): 'undo' | 'redo' {
+  const key = event.key.toLowerCase()
+  if (key === 'y' || (key === 'z' && event.shiftKey)) return 'redo'
+  return 'undo'
+}
+
+function isEventInsideNoteSurface(
+  event: globalThis.KeyboardEvent,
+  editor: CustomBlockNoteEditor,
+  surface: HTMLElement,
+) {
+  if (editor._tiptapEditor.view.hasFocus()) return true
+
+  const activeElement = surface.ownerDocument.activeElement
+  if (
+    activeElement instanceof Node &&
+    (surface.contains(activeElement) || editor._tiptapEditor.view.dom.contains(activeElement))
+  ) {
+    return true
+  }
+
+  const target = event.target
+  return (
+    target instanceof Node &&
+    (surface.contains(target) || editor._tiptapEditor.view.dom.contains(target))
+  )
+}
+
+function patchEditorYjsUndo(editor: CustomBlockNoteEditor) {
+  const view = editor._tiptapEditor.view
+  patchYUndoPluginDestroy(view)
+  patchYSyncAfterTypeChanged(view)
 }

--- a/src/features/editor/components/note-view.tsx
+++ b/src/features/editor/components/note-view.tsx
@@ -92,7 +92,6 @@ function useNoteYjsUndoShortcutPatch(editor: CustomBlockNoteEditor, editable: bo
 
     const handleKeyDown = (event: globalThis.KeyboardEvent) => {
       if (!isHistoryShortcut(event) || !isEventInsideNoteSurface(event, editor, surface)) return
-      patchEditorYjsUndo(editor)
       event.preventDefault()
       event.stopPropagation()
       runYjsHistoryCommand(editor._tiptapEditor.view, getHistoryDirection(event))

--- a/src/features/editor/utils/__tests__/patch-yundo-destroy.test.ts
+++ b/src/features/editor/utils/__tests__/patch-yundo-destroy.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+import { patchYSyncAfterTypeChanged, patchYUndoPluginDestroy } from '../patch-yundo-destroy'
+import type { Plugin } from '@tiptap/pm/state'
+import type { EditorView } from '@tiptap/pm/view'
+
+describe('patchYUndoPluginDestroy', () => {
+  it('does not stack plugin view wrappers when applied repeatedly', () => {
+    const undoManager = createUndoManager()
+    const plugin = createYUndoPlugin(undoManager)
+    const pluginViewDestroy = vi.fn()
+    const view = createEditorView(plugin, { destroy: pluginViewDestroy })
+
+    patchYUndoPluginDestroy(view as unknown as EditorView)
+    patchYUndoPluginDestroy(view as unknown as EditorView)
+
+    view.pluginViews[0]?.destroy?.()
+
+    expect(pluginViewDestroy).toHaveBeenCalledTimes(1)
+    expect(undoManager.__yundo_saved).toEqual({
+      hasTrackedSelf: true,
+      observers: undoManager._observers,
+    })
+  })
+
+  it('does not stack future plugin view factory wrappers when applied repeatedly', () => {
+    const undoManager = createUndoManager()
+    const originalDestroy = vi.fn()
+    const originalViewFactory = vi.fn(() => ({ destroy: originalDestroy }))
+    const plugin = createYUndoPlugin(undoManager, originalViewFactory)
+    const view = createEditorView(plugin)
+
+    patchYUndoPluginDestroy(view as unknown as EditorView)
+    patchYUndoPluginDestroy(view as unknown as EditorView)
+
+    const nextView = plugin.spec.view?.(view as unknown as EditorView)
+    nextView?.destroy?.()
+
+    expect(originalViewFactory).toHaveBeenCalledTimes(1)
+    expect(originalDestroy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('patchYSyncAfterTypeChanged', () => {
+  it('does not let the forced Yjs sync replace the undo selection', () => {
+    const selectionBeforeUndo = { anchor: 'before-undo' }
+    const selectionAfterUndo = { anchor: 'after-undo' }
+    const binding = {
+      beforeTransactionSelection: selectionBeforeUndo,
+      mux: (run: () => void) => run(),
+      prosemirrorView: {
+        state: {
+          doc: {},
+        },
+      },
+      _typeChanged: vi.fn(),
+      _prosemirrorChanged: vi.fn(() => {
+        binding.beforeTransactionSelection = selectionAfterUndo
+      }),
+    }
+    const plugin = {
+      getState: () => ({ binding }),
+    } as unknown as Plugin
+    const view = createEditorView(plugin)
+
+    patchYSyncAfterTypeChanged(view as unknown as EditorView)
+    binding._typeChanged([], {})
+
+    expect(binding._prosemirrorChanged).toHaveBeenCalledOnce()
+    expect(binding.beforeTransactionSelection).toBe(selectionBeforeUndo)
+  })
+})
+
+function createUndoManager() {
+  const afterTransactionHandler = vi.fn()
+  const afterTransactionObservers = new Set<unknown>([afterTransactionHandler])
+  const undoManager = {
+    _observers: new Map(),
+    afterTransactionHandler,
+    doc: {
+      _observers: new Map([['afterTransaction', afterTransactionObservers]]),
+      on: vi.fn((eventName: 'afterTransaction', handler: unknown) => {
+        undoManager.doc._observers.get(eventName)?.add(handler)
+      }),
+    },
+    trackedOrigins: new Set<unknown>(),
+  } as {
+    _observers: Map<unknown, unknown>
+    afterTransactionHandler: ReturnType<typeof vi.fn>
+    doc: {
+      _observers: Map<string, Set<unknown>>
+      on: ReturnType<typeof vi.fn>
+    }
+    trackedOrigins: Set<unknown>
+    __yundo_saved?: {
+      hasTrackedSelf: boolean
+      observers: unknown
+    }
+  }
+  undoManager.trackedOrigins.add(undoManager)
+  return undoManager
+}
+
+function createYUndoPlugin(
+  undoManager: ReturnType<typeof createUndoManager>,
+  viewFactory: NonNullable<Plugin['spec']['view']> = () => ({}),
+) {
+  const plugin = {
+    getState: () => ({ undoManager }),
+    spec: {
+      view: viewFactory,
+    },
+  } as unknown as Plugin
+  return plugin
+}
+
+function createEditorView(plugin: Plugin, pluginView: { destroy?: () => void } = {}) {
+  return {
+    pluginViews: [pluginView],
+    state: {
+      plugins: [plugin],
+    },
+  }
+}

--- a/src/features/editor/utils/patch-yundo-destroy.ts
+++ b/src/features/editor/utils/patch-yundo-destroy.ts
@@ -42,14 +42,19 @@ export function runYjsHistoryCommand(view: EditorView, direction: 'undo' | 'redo
   if (!undoManager) return
 
   const selectionBookmark = createRelativeSelectionBookmark(view)
-  if (direction === 'redo') {
-    undoManager.redo()
-  } else {
-    undoManager.undo()
-  }
-  if (selectionBookmark) {
-    restoreSelectionBookmark(view, selectionBookmark)
-    setTimeout(() => restoreSelectionBookmark(view, selectionBookmark), 0)
+  try {
+    if (direction === 'redo') {
+      undoManager.redo()
+    } else {
+      undoManager.undo()
+    }
+  } catch (error) {
+    logger.error(`[runYjsHistoryCommand] Failed to ${direction}`, error)
+  } finally {
+    if (selectionBookmark) {
+      restoreSelectionBookmark(view, selectionBookmark)
+      setTimeout(() => restoreSelectionBookmark(view, selectionBookmark), 0)
+    }
   }
 }
 

--- a/src/features/editor/utils/patch-yundo-destroy.ts
+++ b/src/features/editor/utils/patch-yundo-destroy.ts
@@ -1,6 +1,57 @@
+import { AllSelection, NodeSelection, TextSelection } from '@tiptap/pm/state'
 import type { Plugin } from '@tiptap/pm/state'
 import type { EditorView } from '@tiptap/pm/view'
+import { getRelativeSelection, relativePositionToAbsolutePosition } from 'y-prosemirror'
 import { logger } from '~/shared/utils/logger'
+
+const PATCHED_YUNDO_VIEW = Symbol('patchedYUndoPluginView')
+const PATCHED_PLUGIN_VIEW_DESTROY = Symbol('patchedYUndoPluginViewDestroy')
+
+type YUndoManagerLike = {
+  doc: {
+    _observers?: Map<string, Set<unknown>>
+    on: (eventName: 'afterTransaction', handler: unknown) => void
+  }
+  trackedOrigins: Set<unknown>
+}
+
+type MutableYUndoManager = YUndoManagerLike &
+  Record<string, unknown> & {
+    afterTransactionHandler?: unknown
+    __yundo_saved?: {
+      hasTrackedSelf: boolean
+      observers: unknown
+    }
+    _observers?: unknown
+  }
+
+type YUndoPluginView = {
+  destroy?: (() => void) & { [PATCHED_PLUGIN_VIEW_DESTROY]?: true }
+}
+
+type YSyncBindingLike = Parameters<typeof getRelativeSelection>[0]
+
+type RelativeSelectionBookmark = {
+  binding: YSyncBindingLike
+  selection: ReturnType<typeof getRelativeSelection>
+}
+
+export function runYjsHistoryCommand(view: EditorView, direction: 'undo' | 'redo') {
+  const yUndoPlugin = findYUndoPlugin(view)
+  const undoManager = yUndoPlugin?.getState(view.state)?.undoManager
+  if (!undoManager) return
+
+  const selectionBookmark = createRelativeSelectionBookmark(view)
+  if (direction === 'redo') {
+    undoManager.redo()
+  } else {
+    undoManager.undo()
+  }
+  if (selectionBookmark) {
+    restoreSelectionBookmark(view, selectionBookmark)
+    setTimeout(() => restoreSelectionBookmark(view, selectionBookmark), 0)
+  }
+}
 
 /**
  * y-prosemirror's yUndoPlugin unconditionally destroys the UndoManager
@@ -25,6 +76,21 @@ function findYUndoPlugin(view: EditorView): Plugin | undefined {
   })
 }
 
+function findYSyncBinding(view: EditorView): YSyncBindingLike | null {
+  for (const plugin of view.state.plugins) {
+    try {
+      const state = plugin.getState(view.state)
+      if (state && typeof state === 'object' && 'binding' in state && state.binding) {
+        return state.binding as YSyncBindingLike
+      }
+    } catch {
+      /* skip */
+    }
+  }
+
+  return null
+}
+
 export function patchYUndoPluginDestroy(view: EditorView) {
   try {
     const yUndoPlugin = findYUndoPlugin(view)
@@ -34,7 +100,7 @@ export function patchYUndoPluginDestroy(view: EditorView) {
     const um = undoState?.undoManager
     if (!um) return
 
-    const umAny = um as Record<string, any>
+    const umAny = um as MutableYUndoManager
 
     if (typeof umAny.afterTransactionHandler !== 'function') {
       logger.warn('[patchYUndoPluginDestroy] afterTransactionHandler not found, skipping patch')
@@ -44,7 +110,7 @@ export function patchYUndoPluginDestroy(view: EditorView) {
     // If the afterTransactionHandler was unregistered (by a prior destroy),
     // re-register it so the UndoManager tracks changes again.
     const handler = umAny.afterTransactionHandler
-    const observers = um.doc._observers as Map<string, Set<any>> | undefined
+    const observers = um.doc._observers
     const afterTxSet = observers?.get?.('afterTransaction')
     if (!afterTxSet || !afterTxSet.has(handler)) {
       um.doc.on('afterTransaction', handler)
@@ -53,52 +119,9 @@ export function patchYUndoPluginDestroy(view: EditorView) {
       um.trackedOrigins.add(um)
     }
 
-    const originalViewFactory = yUndoPlugin.spec.view as (v: EditorView) => {
-      destroy?: () => void
-    }
+    patchYUndoPluginViewFactory(yUndoPlugin)
 
-    yUndoPlugin.spec.view = (editorView: EditorView) => {
-      const currentUm = yUndoPlugin.getState(editorView.state)?.undoManager
-      if (!currentUm) return originalViewFactory(editorView)
-
-      const currentUmAny = currentUm as Record<string, any>
-
-      if (typeof currentUmAny.afterTransactionHandler !== 'function') {
-        return originalViewFactory(editorView)
-      }
-
-      if (currentUmAny.__yundo_saved) {
-        const saved = currentUmAny.__yundo_saved
-        if (saved.hasTrackedSelf) currentUm.trackedOrigins.add(currentUm)
-        const savedHandler = currentUmAny.afterTransactionHandler
-        if (savedHandler) {
-          const obs = currentUm.doc._observers as Map<string, Set<any>> | undefined
-          const txSet = obs?.get?.('afterTransaction')
-          if (!txSet || !txSet.has(savedHandler)) {
-            currentUm.doc.on('afterTransaction', savedHandler)
-          }
-        }
-        currentUmAny._observers = saved.observers
-        delete currentUmAny.__yundo_saved
-      }
-
-      const result = originalViewFactory(editorView)
-
-      return {
-        ...result,
-        destroy: () => {
-          currentUmAny.__yundo_saved = {
-            hasTrackedSelf: currentUm.trackedOrigins.has(currentUm),
-            observers: currentUmAny._observers,
-          }
-          result?.destroy?.()
-        },
-      }
-    }
-
-    const pluginViews = (view as Record<string, any>).pluginViews as
-      | Array<{ destroy?: () => void }>
-      | undefined
+    const pluginViews = (view as unknown as { pluginViews?: Array<YUndoPluginView> }).pluginViews
     if (!pluginViews) {
       logger.warn('[patchYUndoPluginDestroy] pluginViews not found, skipping pluginView patch')
       return
@@ -107,19 +130,83 @@ export function patchYUndoPluginDestroy(view: EditorView) {
     const pluginIndex = view.state.plugins.indexOf(yUndoPlugin)
     if (pluginIndex === -1 || !pluginViews[pluginIndex]) return
 
-    const existingPluginView = pluginViews[pluginIndex]
-    const originalDestroy = existingPluginView.destroy
-
-    existingPluginView.destroy = () => {
-      umAny.__yundo_saved = {
-        hasTrackedSelf: um.trackedOrigins.has(um),
-        observers: umAny._observers,
-      }
-      originalDestroy?.call(existingPluginView)
-    }
+    patchExistingYUndoPluginView(pluginViews[pluginIndex], um as YUndoManagerLike, umAny)
   } catch (err) {
     logger.warn('[patchYUndoPluginDestroy] Unexpected error, undo patch skipped:', err)
   }
+}
+
+function patchExistingYUndoPluginView(
+  existingPluginView: YUndoPluginView,
+  um: YUndoManagerLike,
+  umAny: MutableYUndoManager,
+) {
+  const originalDestroy = existingPluginView.destroy
+  if (originalDestroy?.[PATCHED_PLUGIN_VIEW_DESTROY]) return
+
+  const patchedDestroy = function patchedYUndoPluginViewDestroy() {
+    saveUndoManager(um, umAny)
+    originalDestroy?.call(existingPluginView)
+  } as (() => void) & { [PATCHED_PLUGIN_VIEW_DESTROY]?: true }
+  patchedDestroy[PATCHED_PLUGIN_VIEW_DESTROY] = true
+  existingPluginView.destroy = patchedDestroy
+}
+
+function patchYUndoPluginViewFactory(yUndoPlugin: Plugin) {
+  const originalViewFactory = yUndoPlugin.spec.view as
+    | (((v: EditorView) => { destroy?: () => void }) & { [PATCHED_YUNDO_VIEW]?: true })
+    | undefined
+  if (!originalViewFactory || originalViewFactory[PATCHED_YUNDO_VIEW]) return
+
+  const patchedViewFactory = ((editorView: EditorView) => {
+    const currentUm = yUndoPlugin.getState(editorView.state)?.undoManager
+    if (!currentUm) return originalViewFactory(editorView)
+
+    const currentUmAny = currentUm as MutableYUndoManager
+
+    if (typeof currentUmAny.afterTransactionHandler !== 'function') {
+      return originalViewFactory(editorView)
+    }
+
+    restoreSavedUndoManager(currentUm, currentUmAny)
+
+    const result = originalViewFactory(editorView)
+
+    return {
+      ...result,
+      destroy: () => {
+        saveUndoManager(currentUm, currentUmAny)
+        result?.destroy?.()
+      },
+    }
+  }) as typeof originalViewFactory
+
+  patchedViewFactory[PATCHED_YUNDO_VIEW] = true
+  yUndoPlugin.spec.view = patchedViewFactory
+}
+
+function saveUndoManager(um: YUndoManagerLike, umAny: MutableYUndoManager) {
+  umAny.__yundo_saved = {
+    hasTrackedSelf: um.trackedOrigins.has(um),
+    observers: umAny._observers,
+  }
+}
+
+function restoreSavedUndoManager(currentUm: YUndoManagerLike, currentUmAny: MutableYUndoManager) {
+  if (!currentUmAny.__yundo_saved) return
+
+  const saved = currentUmAny.__yundo_saved
+  if (saved.hasTrackedSelf) currentUm.trackedOrigins.add(currentUm)
+  const savedHandler = currentUmAny.afterTransactionHandler
+  if (savedHandler) {
+    const obs = currentUm.doc._observers
+    const txSet = obs?.get?.('afterTransaction')
+    if (!txSet || !txSet.has(savedHandler)) {
+      currentUm.doc.on('afterTransaction', savedHandler)
+    }
+  }
+  currentUmAny._observers = saved.observers
+  delete currentUmAny.__yundo_saved
 }
 
 /**
@@ -155,10 +242,16 @@ export function patchYSyncAfterTypeChanged(view: EditorView) {
           const origTypeChanged = binding._typeChanged.bind(binding)
           binding._typeChanged = (events: Array<unknown>, transaction: Record<string, any>) => {
             origTypeChanged(events, transaction)
-            if (binding.prosemirrorView) {
-              binding.mux(() => {
-                binding._prosemirrorChanged(binding.prosemirrorView.state.doc)
-              })
+            const prosemirrorView = binding.prosemirrorView as EditorView | null
+            if (prosemirrorView) {
+              const beforeTransactionSelection = binding.beforeTransactionSelection
+              try {
+                binding.mux(() => {
+                  binding._prosemirrorChanged(prosemirrorView.state.doc)
+                })
+              } finally {
+                binding.beforeTransactionSelection = beforeTransactionSelection
+              }
             }
           }
 
@@ -171,4 +264,56 @@ export function patchYSyncAfterTypeChanged(view: EditorView) {
   } catch (err) {
     logger.warn('[patchYSyncAfterTypeChanged] Unexpected error, patch skipped:', err)
   }
+}
+
+function createRelativeSelectionBookmark(view: EditorView): RelativeSelectionBookmark | null {
+  if (view.state.selection.empty) return null
+
+  const binding = findYSyncBinding(view)
+  if (!binding) return null
+
+  return {
+    binding,
+    selection: getRelativeSelection(binding, view.state),
+  }
+}
+
+function restoreSelectionBookmark(view: EditorView, selectionBookmark: RelativeSelectionBookmark) {
+  const selection = resolveRelativeSelectionBookmark(view, selectionBookmark)
+  if (selection && !view.state.selection.eq(selection)) {
+    view.dispatch(view.state.tr.setSelection(selection).setMeta('addToHistory', false))
+  }
+}
+
+function resolveRelativeSelectionBookmark(
+  view: EditorView,
+  { binding, selection }: RelativeSelectionBookmark,
+) {
+  if (selection.anchor === null || selection.head === null) return null
+
+  if (selection.type === 'all') {
+    return new AllSelection(view.state.doc)
+  }
+
+  const anchor = relativePositionToAbsolutePosition(
+    binding.doc,
+    binding.type,
+    selection.anchor,
+    binding.mapping,
+  )
+  if (anchor === null) return null
+
+  if (selection.type === 'node') {
+    return NodeSelection.create(view.state.doc, anchor)
+  }
+
+  const head = relativePositionToAbsolutePosition(
+    binding.doc,
+    binding.type,
+    selection.head,
+    binding.mapping,
+  )
+  if (head === null) return null
+
+  return TextSelection.between(view.state.doc.resolve(anchor), view.state.doc.resolve(head))
 }

--- a/src/features/filesystem/__tests__/filesystem-hotkeys.test.ts
+++ b/src/features/filesystem/__tests__/filesystem-hotkeys.test.ts
@@ -102,7 +102,9 @@ describe('filesystem undo/redo hotkeys', () => {
     )
 
     act(() => {
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true }))
+      surface.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, bubbles: true }),
+      )
     })
 
     expect(undo).toHaveBeenCalledTimes(1)

--- a/src/features/filesystem/__tests__/filesystem-provider.test.tsx
+++ b/src/features/filesystem/__tests__/filesystem-provider.test.tsx
@@ -758,13 +758,13 @@ describe('FileSystemProvider', () => {
     )
   })
 
-  it('selects created roots after redo', async () => {
+  it('selects created roots after redo without navigating', async () => {
     const staleItem = createNote({ _id: 'stale_item' as Id<'sidebarItems'>, name: 'Stale' })
     const createdItemId = 'item_1' as Id<'sidebarItems'>
     sidebarItems = [staleItem]
     executeMutateAsync.mockResolvedValueOnce(createReceipt())
-    undoMutateAsync.mockResolvedValueOnce(createReceipt())
-    redoMutateAsync.mockResolvedValueOnce(createReceipt())
+    undoMutateAsync.mockResolvedValueOnce({ ...createReceipt(), direction: 'undo' })
+    redoMutateAsync.mockResolvedValueOnce({ ...createReceipt(), direction: 'redo' })
     useSidebarUIStore.getState().setSelectedItemIds([staleItem._id])
 
     render(
@@ -778,12 +778,14 @@ describe('FileSystemProvider', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Undo' }))
     await waitFor(() => expect(useFileSystemUndoStore.getState().redoStack).toHaveLength(1))
     useSidebarUIStore.getState().setSelectedItemIds([staleItem._id])
+    navigateToItemMock.mockClear()
 
     fireEvent.click(screen.getByRole('button', { name: 'Redo' }))
 
     await waitFor(() =>
       expect(useSidebarUIStore.getState().selectedItemIds).toEqual([createdItemId]),
     )
+    expect(navigateToItemMock).not.toHaveBeenCalled()
   })
 
   it('does not push failed operations into undo', async () => {

--- a/src/features/filesystem/filesystem-receipt-selectors.ts
+++ b/src/features/filesystem/filesystem-receipt-selectors.ts
@@ -28,10 +28,12 @@ function createReceiptEventGroups(receipt: FileSystemTransactionReceipt) {
 
 function isNavigationEvent(
   event: FileSystemEvent,
+  direction: FileSystemTransactionReceipt['direction'],
   currentSlug: string | null,
 ): event is Extract<FileSystemEvent, { type: 'created' | 'renamed' }> {
   return (
-    event.type === 'created' || (event.type === 'renamed' && event.previousSlug === currentSlug)
+    (event.type === 'created' && direction === 'forward') ||
+    (event.type === 'renamed' && event.previousSlug === currentSlug)
   )
 }
 
@@ -110,7 +112,7 @@ export function getReceiptNavigationSlug(
 
   const events = createReceiptEventGroups(receipt)
   const event = [...events.created, ...events.renamed].find((candidate) =>
-    isNavigationEvent(candidate, currentSlug),
+    isNavigationEvent(candidate, receipt.direction, currentSlug),
   )
   return event?.slug ?? null
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved undo/redo behavior with selection preservation across editors
  * Lasso tool now automatically switches back to select tool after completing a gesture
  * Enhanced undo/redo hotkey support in canvas text nodes and note editors

* **Tests**
  * Added comprehensive test coverage for undo/redo hotkey behavior

* **Chores**
  * Added y-prosemirror dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ntietje1/wizard-archive/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->